### PR TITLE
feat: configure global mirror deletion safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,11 @@ restorable), not re-uploaded as a brand-new file. This uses the CLI 0.8.0
 
 **Mirror safety:** the deletion pass is skipped (and flagged) if a configured
 source path is missing on disk, if any upload failed during the run, or if more
-than ~30% of the catalog would be removed at once. Re-run after fixing the cause
-to apply pending deletions.
+than the configured share of the catalog would be removed at once. The global
+threshold defaults to 30% and can be changed or disabled under **Settings → Mirror
+safety**. Disabling it affects only the percentage gate; missing sources and upload
+failures always prevent deletion. Re-run after fixing a protected failure to apply
+pending deletions.
 
 ## What gets skipped (a backup is never stopped by one bad file)
 
@@ -285,6 +288,7 @@ All routes are unauthenticated (see [Security](#security)).
 | PATCH/DELETE | `/api/backup-sets/:id` | update / delete a set |
 | POST | `/api/backup-sets/:id/source-paths` | safely add source roots to a stopped set |
 | POST | `/api/backup-sets/:id/run` · `/cancel` · `/verify` | run / cancel / verify a set |
+| GET/POST | `/api/settings/mirror-safety` | read / update the global Mirror deletion threshold |
 
 ## Development
 
@@ -331,6 +335,9 @@ Dockerfile · docker-compose.yml · docker-entrypoint.sh
 Newest first. Image tags follow the bundled `proton-drive` CLI version
 (`<cliVersion>-<revision>`); these are app-level highlights, not per-tag notes.
 
+- **Configurable Mirror deletion threshold** - the global 30% safety gate can be
+  changed or disabled in Settings, while missing-source and upload-failure gates
+  remain mandatory (issue #56).
 - **Safe source additions for existing sets** - select extra local folders, open
   the stopped set's editor, and add them without resetting its upload catalog.
   Existing sources cannot be removed from this workflow, overlapping roots are

--- a/src/app/api/settings/mirror-safety/route.test.ts
+++ b/src/app/api/settings/mirror-safety/route.test.ts
@@ -1,0 +1,52 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { GET, POST } from './route';
+import { getMirrorSafetyConfig } from '@/server/mirror-safety';
+
+const FILE = path.join(path.dirname(process.env.DB_PATH!), 'mirror-safety.json');
+
+function update(body: unknown) {
+  return POST(
+    new Request('http://localhost/api/settings/mirror-safety', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+beforeEach(() => {
+  fs.rmSync(FILE, { force: true });
+});
+
+describe('/api/settings/mirror-safety', () => {
+  it('returns the backwards-compatible 30% default', async () => {
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ enabled: true, deleteSafetyPct: 0.3 });
+  });
+
+  it('persists a threshold and can disable only the percentage gate', async () => {
+    const response = await update({ enabled: false, deleteSafetyPct: 0.6 });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ enabled: false, deleteSafetyPct: 0.6 });
+    expect(getMirrorSafetyConfig()).toEqual({ enabled: false, deleteSafetyPct: 0.6 });
+  });
+
+  it.each([
+    [{ enabled: 'yes' }, /enabled must be a boolean/],
+    [{ deleteSafetyPct: '0.5' }, /must be a number/],
+    [{ deleteSafetyPct: 0 }, /between 0.01 and 0.99/],
+    [{ deleteSafetyPct: 1 }, /between 0.01 and 0.99/],
+  ])('rejects invalid input without changing the default: %j', async (body, error) => {
+    const response = await update(body);
+    const result = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(result.error).toMatch(error);
+    expect(getMirrorSafetyConfig()).toEqual({ enabled: true, deleteSafetyPct: 0.3 });
+  });
+});

--- a/src/app/api/settings/mirror-safety/route.ts
+++ b/src/app/api/settings/mirror-safety/route.ts
@@ -1,0 +1,35 @@
+import { getMirrorSafetyConfig, setMirrorSafetyConfig } from '@/server/mirror-safety';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return Response.json(getMirrorSafetyConfig());
+}
+
+export async function POST(req: Request) {
+  const body = (await req.json().catch(() => ({}))) as Record<string, unknown>;
+  const patch: Parameters<typeof setMirrorSafetyConfig>[0] = {};
+
+  if (body.enabled != null) {
+    if (typeof body.enabled !== 'boolean') {
+      return Response.json({ error: 'enabled must be a boolean' }, { status: 400 });
+    }
+    patch.enabled = body.enabled;
+  }
+
+  if (body.deleteSafetyPct != null) {
+    if (typeof body.deleteSafetyPct !== 'number' || !Number.isFinite(body.deleteSafetyPct)) {
+      return Response.json({ error: 'deleteSafetyPct must be a number' }, { status: 400 });
+    }
+    if (body.deleteSafetyPct < 0.01 || body.deleteSafetyPct > 0.99) {
+      return Response.json({ error: 'deleteSafetyPct must be between 0.01 and 0.99' }, { status: 400 });
+    }
+    patch.deleteSafetyPct = body.deleteSafetyPct;
+  }
+
+  try {
+    return Response.json(setMirrorSafetyConfig(patch));
+  } catch {
+    return Response.json({ error: 'could not persist Mirror safety settings' }, { status: 500 });
+  }
+}

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -3,6 +3,7 @@ import { getCliVersion } from '@/server/cli';
 import { LOCAL_ROOT } from '@/server/local';
 import { getUserInfo } from '@/server/quota';
 import { uploadsView } from '@/server/traffic';
+import { getMirrorSafetyConfig } from '@/server/mirror-safety';
 
 export const dynamic = 'force-dynamic';
 
@@ -10,6 +11,7 @@ export async function GET() {
   const [cli, user] = await Promise.all([getCliVersion(), getUserInfo()]);
   return Response.json({
     uploads: uploadsView(),
+    mirrorSafety: getMirrorSafetyConfig(),
     app: process.env.APP_VERSION || 'dev',
     imageTag: process.env.IMAGE_TAG || 'dev',
     cli,

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -15,6 +15,7 @@ interface Info {
   quota: { maxSpace: number; usedSpace: number; driveUsed: number } | null;
   productUsed: Record<string, number>;
   uploads: UploadsCfg;
+  mirrorSafety: MirrorSafetyCfg;
 }
 interface UploadsCfg {
   concurrency: number;
@@ -24,6 +25,12 @@ interface UploadsCfg {
   canShape: boolean;
   /** Why it can't, when it can't — shown in the UI. */
   shapeReason: string;
+}
+interface MirrorSafetyCfg {
+  /** Percentage gate only; missing sources and upload failures always block deletion. */
+  enabled: boolean;
+  /** Fraction in the range 0.01-0.99. */
+  deleteSafetyPct: number;
 }
 interface Updates {
   cli: { current: string; latest: string; updateAvailable: boolean };
@@ -67,6 +74,8 @@ export default function Settings() {
   const [updates, setUpdates] = useState<Updates | null>(null);
   const [checking, setChecking] = useState(false);
   const [uploads, setUploads] = useState<UploadsCfg | null>(null);
+  const [mirrorSafety, setMirrorSafety] = useState<MirrorSafetyCfg | null>(null);
+  const [mirrorSafetyError, setMirrorSafetyError] = useState<string | null>(null);
 
   const saveUploads = (patch: Partial<UploadsCfg>) => {
     setUploads((u) => (u ? { ...u, ...patch } : u));
@@ -80,6 +89,32 @@ export default function Settings() {
       .catch(() => {});
   };
 
+  const saveMirrorSafety = (patch: Partial<MirrorSafetyCfg>) => {
+    if (!mirrorSafety) return;
+    setMirrorSafety({ ...mirrorSafety, ...patch });
+    setMirrorSafetyError(null);
+    fetch('/api/settings/mirror-safety', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(patch),
+    })
+      .then(async (response) => {
+        const body = await response.json();
+        if (!response.ok) throw new Error(body.error || 'Could not save Mirror safety settings.');
+        return body as MirrorSafetyCfg;
+      })
+      .then(setMirrorSafety)
+      .catch((error) => {
+        setMirrorSafetyError(error instanceof Error ? error.message : 'Could not save Mirror safety settings.');
+        // Re-read the last persisted value. This also correctly rolls back an
+        // unsaved number-field edit, whose optimistic state is already rendered.
+        fetch('/api/settings/mirror-safety')
+          .then((response) => response.json())
+          .then(setMirrorSafety)
+          .catch(() => {});
+      });
+  };
+
   useEffect(() => setMounted(true), []);
 
   // Prefetch settings on mount so the first open renders at its full size instead
@@ -91,6 +126,7 @@ export default function Settings() {
       .then((d) => {
         setInfo(d);
         setUploads(d.uploads);
+        setMirrorSafety(d.mirrorSafety);
       })
       .catch(() => {});
   }, []);
@@ -136,6 +172,8 @@ export default function Settings() {
       .then((d) => {
         setInfo(d);
         setUploads(d.uploads);
+        setMirrorSafety(d.mirrorSafety);
+        setMirrorSafetyError(null);
       })
       .catch(() => {});
     checkUpdates();
@@ -298,6 +336,68 @@ export default function Settings() {
                   ) : (
                     <p className="mt-1 text-[11px] leading-relaxed text-amber-400/80">
                       Unavailable — {uploads.shapeReason} See “Hardening” in the README.
+                    </p>
+                  )}
+                </div>
+              </Section>
+            )}
+
+            {/* Mirror deletion safety */}
+            {mirrorSafety && (
+              <Section title="Mirror safety">
+                <div className="py-1">
+                  <div className="flex items-center justify-between gap-3 text-sm">
+                    <span className="text-[color:var(--muted)]">Prevent large deletions</span>
+                    <input
+                      type="checkbox"
+                      className="h-4 w-4"
+                      checked={mirrorSafety.enabled}
+                      onChange={(e) => saveMirrorSafety({ enabled: e.target.checked })}
+                      aria-label="Enable large Mirror deletion protection"
+                    />
+                  </div>
+
+                  {mirrorSafety.enabled ? (
+                    <div className="mt-2 flex items-center justify-between gap-3 text-sm">
+                      <span className="text-[color:var(--muted)]">Maximum catalog deletion</span>
+                      <div className="flex items-center gap-1.5">
+                        <input
+                          type="number"
+                          min={1}
+                          max={99}
+                          step={1}
+                          value={Math.round(mirrorSafety.deleteSafetyPct * 100)}
+                          onChange={(e) => {
+                            const percentage = Math.min(99, Math.max(1, Math.round(+e.target.value) || 1));
+                            setMirrorSafety((current) =>
+                              current ? { ...current, deleteSafetyPct: percentage / 100 } : current,
+                            );
+                          }}
+                          onBlur={(e) => {
+                            const percentage = Math.min(99, Math.max(1, Math.round(+e.target.value) || 1));
+                            saveMirrorSafety({ deleteSafetyPct: percentage / 100 });
+                          }}
+                          onKeyDown={(e) => e.key === 'Enter' && e.currentTarget.blur()}
+                          className="w-20 rounded bg-white/[0.06] px-2 py-1 text-right text-sm tabular-nums outline-none focus:bg-white/[0.09]"
+                          aria-label="Maximum Mirror deletion percentage"
+                        />
+                        <span className="text-xs text-[color:var(--muted)]">%</span>
+                      </div>
+                    </div>
+                  ) : (
+                    <p className="mt-2 text-[11px] leading-relaxed text-amber-400/80">
+                      The percentage guard is disabled. Intentional large Mirror deletions can proceed.
+                    </p>
+                  )}
+
+                  <p className="mt-1 text-[11px] leading-relaxed text-[color:var(--muted)]">
+                    A Mirror run skips deletion when more than this share of its catalog disappears. The default is
+                    30%. Missing sources and failed uploads always block deletion. Changes apply to the next run and
+                    its preview.
+                  </p>
+                  {mirrorSafetyError && (
+                    <p className="mt-1 text-[11px] leading-relaxed text-[color:var(--signal-danger)]">
+                      {mirrorSafetyError}
                     </p>
                   )}
                 </div>

--- a/src/server/engine.test.ts
+++ b/src/server/engine.test.ts
@@ -28,6 +28,7 @@ import * as cli from '@/server/cli';
 import { catalog } from '@/server/catalog';
 import { LOCAL_ROOT } from '@/server/local';
 import { getDb } from '@/server/db';
+import { setMirrorSafetyConfig } from '@/server/mirror-safety';
 
 const upload = vi.mocked(cli.upload);
 const createFolder = vi.mocked(cli.createFolder);
@@ -50,6 +51,8 @@ beforeEach(() => {
   upload.mockClear();
   createFolder.mockClear();
   trashDrive.mockClear();
+  // Every test starts with the historical behavior used by existing installs.
+  setMirrorSafetyConfig({ enabled: true, deleteSafetyPct: 0.3 });
   // Reset to the default happy-path implementations (tests may override).
   upload.mockResolvedValue({ code: 0, stdout: '', stderr: '' });
   createFolder.mockResolvedValue({ ok: true, data: {} } as any);
@@ -246,7 +249,7 @@ describe('runCatalogDelta — mirror deletion + safety gates', () => {
     expect(catalog.getFile('m1set', 'Set/m1/f3.txt')).toBeUndefined();
   });
 
-  it('safety gate: skips deletion entirely when a source path is missing on disk', async () => {
+  it('hard safety gate: skips deletion when a source is missing even if the percentage gate is disabled', async () => {
     const srcDir = path.join(LOCAL_ROOT, 'm2');
     for (let i = 0; i < 10; i++) await writeFixture(`m2/f${i}.txt`, `data-${i}`);
 
@@ -256,6 +259,7 @@ describe('runCatalogDelta — mirror deletion + safety gates', () => {
     // Remove the ENTIRE source directory: every file is now "stale", but because the
     // configured source path itself is gone, the engine must NOT trash anything.
     await fsp.rm(srcDir, { recursive: true, force: true });
+    setMirrorSafetyConfig({ enabled: false });
 
     const res = await runCatalogDelta('m2set', [srcDir], '/', 'Set', 'mirror');
 
@@ -292,6 +296,44 @@ describe('runCatalogDelta — mirror deletion + safety gates', () => {
     expect(res.message).toMatch(/would be removed|>30%/);
     // Surviving + removed catalog entries are all still present (nothing trashed).
     expect(catalog.getFile('m3set', 'Set/m3/f0.txt')).toBeDefined();
+  });
+
+  it('uses a custom global threshold for the live Mirror deletion pass', async () => {
+    const srcDir = path.join(LOCAL_ROOT, 'm-custom');
+    for (let i = 0; i < 5; i++) await writeFixture(`m-custom/f${i}.txt`, `data-${i}`);
+    await seed('m-custom-set', srcDir);
+    trashDrive.mockClear();
+
+    // Three missing file rows exceed the historical 30% threshold. Raising the
+    // global threshold to 80% must permit this intentional deletion.
+    await fsp.rm(path.join(srcDir, 'f0.txt'));
+    await fsp.rm(path.join(srcDir, 'f1.txt'));
+    await fsp.rm(path.join(srcDir, 'f2.txt'));
+    setMirrorSafetyConfig({ enabled: true, deleteSafetyPct: 0.8 });
+
+    const res = await runCatalogDelta('m-custom-set', [srcDir], '/', 'Set', 'mirror');
+
+    expect(res.ok).toBe(true);
+    expect(res.deletedCount).toBe(3);
+    expect(trashDrive).toHaveBeenCalledTimes(3);
+    expect(res.message).toContain('3 removed');
+  });
+
+  it('can disable only the percentage gate for an intentional full Mirror deletion', async () => {
+    const srcDir = path.join(LOCAL_ROOT, 'm-disabled');
+    for (let i = 0; i < 5; i++) await writeFixture(`m-disabled/f${i}.txt`, `data-${i}`);
+    await seed('m-disabled-set', srcDir);
+    trashDrive.mockClear();
+
+    for (let i = 0; i < 5; i++) await fsp.rm(path.join(srcDir, `f${i}.txt`));
+    setMirrorSafetyConfig({ enabled: false });
+
+    const res = await runCatalogDelta('m-disabled-set', [srcDir], '/', 'Set', 'mirror');
+
+    expect(res.ok).toBe(true);
+    expect(res.deletedCount).toBeGreaterThan(0);
+    expect(trashDrive).toHaveBeenCalled();
+    expect(catalog.count('m-disabled-set')).toBe(0);
   });
 
   it('backup mode never trashes, even when a file vanished locally', async () => {
@@ -440,6 +482,29 @@ describe('previewDelta (dry run — read-only)', () => {
     expect(p.deletionWouldSkip).toMatch(/source path is missing/i);
   });
 
+  it('mirror: uses the same custom or disabled percentage gate as a live run', async () => {
+    const srcDir = path.join(LOCAL_ROOT, 'pv-safety');
+    for (let i = 0; i < 5; i++) await writeFixture(`pv-safety/f${i}.txt`, `data-${i}`);
+    await runCatalogDelta('pv-safety-set', [srcDir], '/', 'Set', 'mirror');
+    await fsp.rm(path.join(srcDir, 'f0.txt'));
+    await fsp.rm(path.join(srcDir, 'f1.txt'));
+    await fsp.rm(path.join(srcDir, 'f2.txt'));
+
+    setMirrorSafetyConfig({ enabled: true, deleteSafetyPct: 0.2 });
+    const blocked = await previewDelta('pv-safety-set', [srcDir], 'Set', 'mirror');
+    expect(blocked.deletionWouldSkip).toMatch(/>20%/);
+
+    setMirrorSafetyConfig({ enabled: true, deleteSafetyPct: 0.8 });
+    const allowed = await previewDelta('pv-safety-set', [srcDir], 'Set', 'mirror');
+    expect(allowed.deletionWouldSkip).toBeNull();
+    expect(allowed.wouldDeleteCount).toBe(3);
+
+    setMirrorSafetyConfig({ enabled: false });
+    const disabled = await previewDelta('pv-safety-set', [srcDir], 'Set', 'mirror');
+    expect(disabled.deletionWouldSkip).toBeNull();
+    expect(trashDrive).not.toHaveBeenCalled();
+  });
+
   it('backup mode never reports deletions', async () => {
     const srcDir = path.join(LOCAL_ROOT, 'pv5');
     await writeFixture('pv5/a.txt', 'aaa');
@@ -539,11 +604,13 @@ describe('runCatalogDelta — per-file failure isolation (issue #22)', () => {
       if (absList.some((p) => p.endsWith('f0.txt'))) return { code: 1, stdout: '', stderr: 'boom' };
       return { code: 0, stdout: '', stderr: '' };
     });
+    setMirrorSafetyConfig({ enabled: false });
 
     const res = await runCatalogDelta('iso3set', [srcDir], '/', 'Set', 'mirror');
 
     expect(res.failedCount).toBe(1);
-    // Safety gate #2 (an upload failed) → deletion skipped, nothing trashed.
+    // Hard safety gate #2 (an upload failed) remains active when the percentage
+    // gate is disabled → deletion is skipped and nothing is trashed.
     expect(trashDrive).not.toHaveBeenCalled();
     expect(res.deletedCount).toBe(0);
     expect(res.message).toMatch(/failed to upload|deletion skipped/i);

--- a/src/server/engine.ts
+++ b/src/server/engine.ts
@@ -4,6 +4,7 @@ import { createReadStream, promises as fsp } from 'node:fs';
 import { walkSourceStream, relToLocalRoot, LOCAL_ROOT, type WalkedFile } from './local';
 import { catalog, diffFile } from './catalog';
 import { getUploadConfig } from './upload-config';
+import { getMirrorSafetyConfig } from './mirror-safety';
 import {
   createFolder,
   upload,
@@ -21,10 +22,12 @@ import {
 const SESSION_EXPIRED_MSG =
   'Proton session expired — reconnect to Proton Drive to resume. Nothing was deleted and your backup set is unchanged.';
 
-/** A mirror run that would remove more than this fraction of the catalog skips the
- *  deletion pass and flags it, rather than trashing a huge swath in one go. Shared
- *  by the live run and the read-only preview so both agree on what's "too much". */
-const DELETE_SAFETY_PCT = 0.3;
+/** Snapshot the global percentage gate at the start of a run or preview. `null`
+ *  disables only this gate; missing-source and failed-upload gates stay active. */
+function configuredDeleteSafetyPct(): number | null {
+  const config = getMirrorSafetyConfig();
+  return config.enabled ? config.deleteSafetyPct : null;
+}
 
 /** Base backoff between the transient upload retries (exponential: base, 2×, 4×).
  *  Overridable via env so the test suite doesn't wait out real seconds. */
@@ -251,6 +254,9 @@ export async function runCatalogDelta(
   shouldCancel: () => boolean = () => false,
   opts: { skipThumbnails?: boolean; includeHidden?: boolean } = {},
 ): Promise<DeltaResult> {
+  // Keep one stable value for the whole run. Existing installations with no
+  // settings file resolve to the historical 30% default.
+  const DELETE_SAFETY_PCT = configuredDeleteSafetyPct();
   const { skipThumbnails = false, includeHidden = false } = opts;
   const target = normalizeProtonPath(targetPath);
   // Each source is laid out at "<target>/<subfolder>/<source rel to LOCAL_ROOT>",
@@ -684,8 +690,8 @@ export async function runCatalogDelta(
   //   (2) if ANY upload failed this run (a changed file that didn't make it to
   //       Drive keeps its old catalog timestamp and would look "stale"), skip
   //       deletion — we must not trash a present-but-failed file's Drive copy.
-  //   (3) if a run would remove more than DELETE_SAFETY_PCT of the catalog, skip
-  //       deletion and flag it rather than trash a huge swath in one go.
+  //   (3) if the configurable percentage gate is enabled and a run would remove
+  //       more than DELETE_SAFETY_PCT of the catalog, skip deletion and flag it.
   let deletionSkipped: string | null = null;
   if (mode === 'mirror' && !cancelled) {
     let sourcesIntact = true;
@@ -706,7 +712,7 @@ export async function runCatalogDelta(
       deletionSkipped = 'a source path is missing on disk (mount offline?)';
     } else if (failedCount > 0) {
       deletionSkipped = `${failedCount} file(s) failed to upload — "gone locally" can't be trusted until uploads succeed`;
-    } else if (pctGone > DELETE_SAFETY_PCT) {
+    } else if (DELETE_SAFETY_PCT !== null && pctGone > DELETE_SAFETY_PCT) {
       deletionSkipped = `${stale.length}/${totalEntries} entries (>${Math.round(DELETE_SAFETY_PCT * 100)}%) would be removed`;
     }
 
@@ -803,8 +809,9 @@ export interface PreviewResult {
  * new/changed/unchanged + bytes, and for mirror mode it reproduces the deletion
  * pass by checking which catalog entries no longer exist on disk (bounded memory —
  * it stats each entry instead of marking seen_at) and applies the same safety gates
- * (missing source mount, >30% wipe). Lets the user see exactly what a backup/mirror
- * would change — especially which Drive files a mirror would delete — before running.
+ * (missing source mount, configured percentage gate). Lets the user see exactly
+ * what a backup/mirror would change — especially which Drive files a mirror would
+ * delete — before running.
  */
 export async function previewDelta(
   setId: string,
@@ -815,6 +822,9 @@ export async function previewDelta(
   shouldCancel: () => boolean = () => false,
   includeHidden = false,
 ): Promise<PreviewResult> {
+  // Snapshot the same global value as a live run so the preview and execution
+  // agree even if the user changes Settings while this local walk is in progress.
+  const DELETE_SAFETY_PCT = configuredDeleteSafetyPct();
   const sources = sourcePaths.map((abs) => ({ abs, relBase: relBaseFor(subfolder, abs) }));
   const managedRoots = new Set([subfolder]);
   const matchExclude = makeExcluder(excludes);
@@ -897,7 +907,7 @@ export async function previewDelta(
     const pctGone = totalEntries > 0 ? missing.length / totalEntries : 0;
     if (!sourcesIntact) {
       deletionWouldSkip = 'a source path is missing on disk (mount offline?)';
-    } else if (pctGone > DELETE_SAFETY_PCT) {
+    } else if (DELETE_SAFETY_PCT !== null && pctGone > DELETE_SAFETY_PCT) {
       deletionWouldSkip = `${missing.length}/${totalEntries} entries (>${Math.round(DELETE_SAFETY_PCT * 100)}%) would be removed`;
     }
   }

--- a/src/server/mirror-safety.test.ts
+++ b/src/server/mirror-safety.test.ts
@@ -1,0 +1,72 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  DEFAULT_DELETE_SAFETY_PCT,
+  getMirrorSafetyConfig,
+  setMirrorSafetyConfig,
+} from '@/server/mirror-safety';
+
+const FILE = path.join(path.dirname(process.env.DB_PATH!), 'mirror-safety.json');
+
+beforeEach(() => {
+  fs.rmSync(FILE, { force: true });
+});
+
+describe('global Mirror deletion safety', () => {
+  it('keeps the historical 30% default when no settings file exists', () => {
+    expect(getMirrorSafetyConfig()).toEqual({
+      enabled: true,
+      deleteSafetyPct: DEFAULT_DELETE_SAFETY_PCT,
+    });
+  });
+
+  it('falls back to 30% when the settings file is malformed', () => {
+    fs.writeFileSync(FILE, '{broken-json');
+
+    expect(getMirrorSafetyConfig()).toEqual({
+      enabled: true,
+      deleteSafetyPct: DEFAULT_DELETE_SAFETY_PCT,
+    });
+  });
+
+  it('persists a custom threshold and the explicit disabled state', () => {
+    expect(setMirrorSafetyConfig({ deleteSafetyPct: 0.55 })).toEqual({
+      enabled: true,
+      deleteSafetyPct: 0.55,
+    });
+    expect(setMirrorSafetyConfig({ enabled: false })).toEqual({
+      enabled: false,
+      deleteSafetyPct: 0.55,
+    });
+    expect(getMirrorSafetyConfig()).toEqual({
+      enabled: false,
+      deleteSafetyPct: 0.55,
+    });
+    expect(JSON.parse(fs.readFileSync(FILE, 'utf8'))).toEqual({
+      v: 1,
+      enabled: false,
+      deleteSafetyPct: 0.55,
+    });
+  });
+
+  it('normalizes invalid stored values without throwing into a backup run', () => {
+    fs.writeFileSync(FILE, JSON.stringify({ v: 1, enabled: 'no', deleteSafetyPct: 'invalid' }));
+
+    expect(getMirrorSafetyConfig()).toEqual({
+      enabled: true,
+      deleteSafetyPct: DEFAULT_DELETE_SAFETY_PCT,
+    });
+
+    fs.writeFileSync(FILE, 'null');
+    expect(getMirrorSafetyConfig()).toEqual({
+      enabled: true,
+      deleteSafetyPct: DEFAULT_DELETE_SAFETY_PCT,
+    });
+  });
+
+  it('clamps direct callers to the supported 1-99% range', () => {
+    expect(setMirrorSafetyConfig({ deleteSafetyPct: 0 }).deleteSafetyPct).toBe(0.01);
+    expect(setMirrorSafetyConfig({ deleteSafetyPct: 10 }).deleteSafetyPct).toBe(0.99);
+  });
+});

--- a/src/server/mirror-safety.ts
+++ b/src/server/mirror-safety.ts
@@ -1,0 +1,77 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Global Mirror deletion safety, persisted next to the SQLite database.
+ *
+ * Existing installations have no file, so reads must always fall back to the
+ * historical 30% threshold. A missing, unreadable, or malformed settings file
+ * must never prevent a backup from running.
+ */
+const FILE = path.join(path.dirname(process.env.DB_PATH || '/data/backup.db'), 'mirror-safety.json');
+
+export const DEFAULT_DELETE_SAFETY_PCT = 0.3;
+
+export interface MirrorSafetyConfig {
+  /** Disable only the percentage gate. Missing sources and upload failures stay protected. */
+  enabled: boolean;
+  /** Fraction of catalog entries (0.01-0.99) that may disappear in one Mirror run. */
+  deleteSafetyPct: number;
+}
+
+const DEFAULTS: MirrorSafetyConfig = {
+  enabled: true,
+  deleteSafetyPct: DEFAULT_DELETE_SAFETY_PCT,
+};
+const CONFIG_VERSION = 1;
+const MIN_DELETE_SAFETY_PCT = 0.01;
+// Keep 100% reserved for the explicit disabled state. Otherwise the UI could say
+// the guard is enabled while a complete catalog wipe still bypasses it.
+const MAX_DELETE_SAFETY_PCT = 0.99;
+
+function clampDeleteSafetyPct(value: unknown, fallback: number): number {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(MAX_DELETE_SAFETY_PCT, Math.max(MIN_DELETE_SAFETY_PCT, n));
+}
+
+export function getMirrorSafetyConfig(): MirrorSafetyConfig {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(FILE, 'utf8')) as unknown;
+  } catch {
+    return { ...DEFAULTS };
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { ...DEFAULTS };
+  }
+  const raw = parsed as { enabled?: unknown; deleteSafetyPct?: unknown };
+
+  return {
+    enabled: typeof raw.enabled === 'boolean' ? raw.enabled : DEFAULTS.enabled,
+    deleteSafetyPct: clampDeleteSafetyPct(raw.deleteSafetyPct, DEFAULTS.deleteSafetyPct),
+  };
+}
+
+export function setMirrorSafetyConfig(patch: Partial<MirrorSafetyConfig>): MirrorSafetyConfig {
+  const current = getMirrorSafetyConfig();
+  const next: MirrorSafetyConfig = {
+    enabled: typeof patch.enabled === 'boolean' ? patch.enabled : current.enabled,
+    deleteSafetyPct: clampDeleteSafetyPct(patch.deleteSafetyPct, current.deleteSafetyPct),
+  };
+
+  fs.mkdirSync(path.dirname(FILE), { recursive: true });
+  const temporary = `${FILE}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    fs.writeFileSync(temporary, JSON.stringify({ v: CONFIG_VERSION, ...next }));
+    fs.renameSync(temporary, FILE);
+  } catch (error) {
+    try {
+      fs.rmSync(temporary, { force: true });
+    } catch {
+      // Preserve the original write error.
+    }
+    throw error;
+  }
+  return next;
+}


### PR DESCRIPTION
## Summary

- add a global Settings control for the Mirror deletion percentage gate
- preserve the historical enabled 30% default when no valid settings file exists
- allow an explicit opt-out while keeping missing-source and failed-upload deletion blocks mandatory
- keep live runs and dry-run previews on the same snapshotted setting

## Verification

- npm test: 271 passed
- npm run typecheck
- npm run build
- built-server API and Settings UI smoke test
- Docker deployment smoke runs in GitHub CI because Docker is unavailable locally

Fixes #56